### PR TITLE
Pin vizarr version to fix channel_axis error

### DIFF
--- a/imjoy-plugins/hani-ms2-sample-1.imjoy.html
+++ b/imjoy-plugins/hani-ms2-sample-1.imjoy.html
@@ -92,7 +92,7 @@ class ImJoyPlugin {
     const targetUrl = 'https://imjoy-s3.pasteur.fr/public/mueller-hani-ms2/sample-1/image.ome.tif'
 
     const store = await FileReferenceStore.fromUrl(refUrl, targetUrl);
-    const viewer = await api.createWindow({src: 'https://hms-dbmi.github.io/vizarr', fullscreen: true, name: 'Hani et al., Sample 1'})
+    const viewer = await api.createWindow({src: 'https://oeway.github.io/vizarr', fullscreen: true, name: 'Hani et al., Sample 1'})
     const img = {
       "source": store,
       "name": "pSPX1::MS2x128, S line",

--- a/imjoy-plugins/hani-ms2-sample-1.imjoy.html
+++ b/imjoy-plugins/hani-ms2-sample-1.imjoy.html
@@ -92,7 +92,7 @@ class ImJoyPlugin {
     const targetUrl = 'https://imjoy-s3.pasteur.fr/public/mueller-hani-ms2/sample-1/image.ome.tif'
 
     const store = await FileReferenceStore.fromUrl(refUrl, targetUrl);
-    const viewer = await api.createWindow({src: 'https://oeway.github.io/vizarr', fullscreen: true, name: 'Hani et al., Sample 1'})
+    const viewer = await api.createWindow({src: 'https://unpkg.com/@hms-dbmi/vizarr@0.2.0/index.html', fullscreen: true, name: 'Hani et al., Sample 1'})
     const img = {
       "source": store,
       "name": "pSPX1::MS2x128, S line",

--- a/imjoy-plugins/hani-ms2-sample-2.imjoy.html
+++ b/imjoy-plugins/hani-ms2-sample-2.imjoy.html
@@ -92,7 +92,7 @@ class ImJoyPlugin {
     const targetUrl = 'https://imjoy-s3.pasteur.fr/public/mueller-hani-ms2/sample-2/image.ome.tif'
 
     const store = await FileReferenceStore.fromUrl(refUrl, targetUrl);
-    const viewer = await api.createWindow({src: 'https://hms-dbmi.github.io/vizarr', fullscreen: true, name: 'Hani et al., Sample 2'})
+    const viewer = await api.createWindow({src: 'https://unpkg.com/@hms-dbmi/vizarr@0.2.0/index.html', fullscreen: true, name: 'Hani et al., Sample 2'})
     const img = {
       "source": store,
       "name": "pSPX1::MS2x128, S line",

--- a/imjoy-plugins/hani-ms2-sample-3.imjoy.html
+++ b/imjoy-plugins/hani-ms2-sample-3.imjoy.html
@@ -92,7 +92,7 @@ class ImJoyPlugin {
     const targetUrl = 'https://imjoy-s3.pasteur.fr/public/mueller-hani-ms2/sample-3/image.ome.tif'
 
     const store = await FileReferenceStore.fromUrl(refUrl, targetUrl);
-    const viewer = await api.createWindow({src: 'https://hms-dbmi.github.io/vizarr', fullscreen: true, name: 'Hani et al., Sample 3'})
+    const viewer = await api.createWindow({src: 'https://unpkg.com/@hms-dbmi/vizarr@0.2.0/index.html', fullscreen: true, name: 'Hani et al., Sample 3'})
     const img = {
       "source": store,
       "name": "pSPX1::MS2x128, S line",


### PR DESCRIPTION
Due to recent changes in vizarr v0.2.1, the plant examples does not work anymore.
The error message is: 
```
Error: channel_axis is length undefined and provided channel_axis property channelProp is different size.
```

This PR fix it by pin the vizarr version to https://unpkg.com/@hms-dbmi/vizarr@0.2.0/index.html